### PR TITLE
Demo project work with current version of Django

### DIFF
--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -31,13 +31,12 @@ INSTALLED_APPS = [
 
 STATIC_ROOT = 'static'
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',    
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -75,6 +74,7 @@ DATABASES = {
     }
 }
 
+DEFAULT_AUTO_FIELD = 'django.db.models.SmallAutoField'
 
 # Password validation
 # https://docs.djangoproject.com/en/1.9/ref/settings/#auth-password-validators


### PR DESCRIPTION
Demo project seems outdated and does not work with the current version of Django. Made the following changes to `settings.py` to get it to work:

- `MIDDLEWARE_CLASSES` has been renamed to just `MIDDLEWARE`
- Removed `django.contrib.auth.middleware.SessionAuthenticationMiddleware` from middleware as its been deprecated (baked in now)
- Add `DEFAULT_AUTO_FIELD = 'django.db.models.SmallAutoField'` to remove these warnings when project starts up:
```
testapp.Player: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
testapp.Team: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
```