### PR TITLE
Fix dummy mistake, make imports compatible with Django 4.0

### DIFF
--- a/django_addanother/contrib/select2.py
+++ b/django_addanother/contrib/select2.py
@@ -26,7 +26,7 @@ def _gen_classes(globals_, locals_):
 
         def optgroups(self, name, value, attrs=None):
             optgroups = super({new_widget_cls}, self).optgroups(
-                self, name, value, attrs=attrs)
+                name, value, attrs=attrs)
             if not self.is_required and not self.allow_multiple_selected:
                 # In this case select2 widget adds one more option. 
                 # We can just drop it now

--- a/django_addanother/views.py
+++ b/django_addanother/views.py
@@ -4,7 +4,10 @@ import sys
 import django
 from django.contrib.admin.options import IS_POPUP_VAR
 from django.template.response import SimpleTemplateResponse
-from django.utils.encoding import force_text
+try:
+    from django.utils.encoding import force_text
+except ImportError:
+    from django.utils.encoding import force_str as force_text
 
 
 PY2 = sys.version_info[0] == 2


### PR DESCRIPTION
I worked on issue with duplicated empty label previously and made an ugly mistake (or typo): there was call like `super().__init__(self, ...)`, so calls were just crashing there. It's an urgent fix (classes based on that mixin are unusable now).

Also it was easy to basically support `Django 4.0` by fixing a single import, I added a separate commit for it.